### PR TITLE
Update slam.launch.py

### DIFF
--- a/linorobot2_navigation/launch/slam.launch.py
+++ b/linorobot2_navigation/launch/slam.launch.py
@@ -14,6 +14,7 @@
 
 import os
 from launch import LaunchDescription
+from launch import LaunchContext
 from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch.launch_description_sources import PythonLaunchDescriptionSource
@@ -35,11 +36,12 @@ def generate_launch_description():
     rviz_config_path = PathJoinSubstitution(
         [FindPackageShare('linorobot2_navigation'), 'rviz', 'linorobot2_slam.rviz']
     )
-
+    
+    lc = LaunchContext()
     ros_distro = EnvironmentVariable('ROS_DISTRO')
-    slam_param_name = 'params_file'
-    if ros_distro == 'galactic': 
-        slam_param_name = 'slam_params_file'
+    slam_param_name = 'slam_params_file'
+    if ros_distro.perform(lc) == 'foxy': 
+        slam_param_name = 'params_file'
 
     return LaunchDescription([
         DeclareLaunchArgument(


### PR DESCRIPTION
I don't know if this is something just with my setup or not because I'm curious why this hasn't come up before (unless no one has tried to tweak slam.yaml) but for me, the test as to whether ROS_DISTRO was galactic always failed because it was testing an EnvironmentVariable object against a string.  This meant that all changes to slam.yaml in the linorobot2_navigation package was ignored since it loaded its default from the slamtoolbox package.   

Anyway,  I found in the unit tests you needed to use .perform(lc) where lc is the LaunchContext to get the string from the EnvironmentVariable object.  And since humble is out, it made more sense to me to test whether the distro was foxy and if so, use the old parameter and if not, use the new one.