### PR TITLE
add micro-ROS wifi transport and ldlidar stl drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ robot_type:
 laser_sensor:
 - `rplidar` - [RP LIDAR A1](https://www.slamtec.com/en/Lidar/A1)
 - `ldlidar` - [LD06 LIDAR](https://www.inno-maker.com/product/lidar-ld06/)
+- `ld06` - [LD06 LIDAR](https://www.ldrobot.com/ProductDetails?sensor_name=STL-06P)
+- `ld19` - [LD19/LD300 LIDAR](https://www.ldrobot.com/ProductDetails?sensor_name=STL-19P)
+- `stl27l` - [STL27L LIDAR](https://www.ldrobot.com/ProductDetails?sensor_name=STL-27L)
 - `ydlidar` - [YDLIDAR](https://www.ydlidar.com/lidars.html)
 - `xv11` - [XV11](http://xv11hacking.rohbotics.com/mainSpace/home.html)
 - `realsense` - * [Intel RealSense](https://www.intelrealsense.com/stereo-depth/) D435, D435i

--- a/README.md
+++ b/README.md
@@ -149,6 +149,14 @@ Optional parameters:
     ```
     ros2 launch linorobot2_bringup bringup.launch.py base_serial_port:=/dev/ttyACM1
     ```
+- **micro_ros_transport** - micro-ROS transport. default serial.
+- **micro_ros_port** - micro-ROS udp/tcp port number. default 8888.
+
+    ```
+    # use micro-ROS wifi transport
+    ros2 launch linorobot2_bringup bringup.launch.py micro_ros_transport:=udp4 micro_ros_port:=8888
+    ```
+
 - **joy** - Set to true to run the joystick node in the background. (Tested on Logitech F710).
 
 Always wait for the microROS agent to be connected before running any application (ie. creating a map or autonomous navigation). Once connected, the agent will print:

--- a/ROBOT_INSTALLATION.md
+++ b/ROBOT_INSTALLATION.md
@@ -48,6 +48,13 @@ XV11:
     colcon build
     source <your_ws>/install/setup.bash
 
+LD06 LD19 STL27L:
+
+    cd <your_ws>
+    git clone https://github.com/hippo5329/ldlidar_stl_ros2.git src/ldlidar_stl_ros2
+    colcon build
+    source <your_ws>/install/setup.bash
+
 #### 1.3 Install depth sensor drivers:
 Intel RealSense:
 
@@ -140,6 +147,9 @@ The launch files of the tested laser sensors have already been added in bringup.
 Tested Laser Sensors:
 - `rplidar` - [RP LIDAR A1](https://www.slamtec.com/en/Lidar/A1)
 - `ldlidar` - [LD06 LIDAR](https://www.inno-maker.com/product/lidar-ld06/)
+- `ld06` - [LD06 LIDAR](https://www.ldrobot.com/ProductDetails?sensor_name=STL-06P)
+- `ld19` - [LD19/LD300 LIDAR](https://www.ldrobot.com/ProductDetails?sensor_name=STL-19P)
+- `stl27l` - [STL27L LIDAR](https://www.ldrobot.com/ProductDetails?sensor_name=STL-27L)
 - `ydlidar` - [YDLIDAR](https://www.ydlidar.com/lidars.html)
 - `realsense` - [Intel RealSense](https://www.intelrealsense.com/stereo-depth/) D435, D435i
 - `astra` - [Orbec Astra](https://orbbec3d.com/product-astra-pro/)

--- a/docker/install_sensors.bash
+++ b/docker/install_sensors.bash
@@ -25,7 +25,7 @@ WORKSPACE="/root/linorobot2_ws"
 
 ROBOT_TYPE_ARRAY=(2wd 4wd mecanum)
 DEPTH_SENSOR_ARRAY=(realsense zed zedm zed2 zed2i oakd oakdlite oakdpro)
-LASER_SENSOR_ARRAY=(rplidar ldlidar ydlidar xv11)
+LASER_SENSOR_ARRAY=(rplidar ldlidar ydlidar xv11 ld06 ld19 stl27l)
 LASER_SENSOR_ARRAY+=(${DEPTH_SENSOR_ARRAY[@]})
 
 if [ -z "$LASER_SENSOR" ]
@@ -85,6 +85,25 @@ function install_ydlidar {
     chmod 0777 src/ydlidar_ros2_driver/startup/*
     colcon build --symlink-install
     source $WORKSPACE/install/setup.bash
+}
+
+function install_ldlidar_stl_ros2 {
+    cd $WORKSPACE
+    git clone https://github.com/hippo5329/ldlidar_stl_ros2.git src/ldlidar_stl_ros2
+    colcon build
+    source $WORKSPACE/install/setup.bash
+}
+
+function install_ld06 {
+    install_ldlidar_stl_ros2
+}
+
+function install_ld19 {
+    install_ldlidar_stl_ros2
+}
+
+function install_stl27l {
+    install_ldlidar_stl_ros2
 }
 
 function install_realsense {

--- a/install_linorobot2.bash
+++ b/install_linorobot2.bash
@@ -24,7 +24,7 @@ WORKSPACE="$HOME/linorobot2_ws"
 
 ROBOT_TYPE_ARRAY=(2wd 4wd mecanum)
 DEPTH_SENSOR_ARRAY=(realsense zed zedm zed2 zed2i oakd oakdlite oakdpro)
-LASER_SENSOR_ARRAY=(rplidar ldlidar ydlidar xv11)
+LASER_SENSOR_ARRAY=(rplidar ldlidar ydlidar xv11 ld06 ld19 stl27l)
 LASER_SENSOR_ARRAY+=(${DEPTH_SENSOR_ARRAY[@]})
 
 if [ -z "$LASER_SENSOR" ]
@@ -71,6 +71,25 @@ function install_ldlidar {
     sudo cp src/ldlidar/ldlidar.rules /etc/udev/rules.d/
     colcon build
     source $WORKSPACE/install/setup.bash
+}
+
+function install_ldlidar_stl_ros2 {
+    cd $WORKSPACE
+    git clone https://github.com/hippo5329/ldlidar_stl_ros2.git src/ldlidar_stl_ros2
+    colcon build
+    source $WORKSPACE/install/setup.bash
+}
+
+function install_ld06 {
+    install_ldlidar_stl_ros2
+}
+
+function install_ld19 {
+    install_ldlidar_stl_ros2
+}
+
+function install_stl27l {
+    install_ldlidar_stl_ros2
 }
 
 function install_ydlidar {

--- a/linorobot2_bringup/launch/bringup.launch.py
+++ b/linorobot2_bringup/launch/bringup.launch.py
@@ -70,6 +70,18 @@ def generate_launch_description():
         ),
 
         DeclareLaunchArgument(
+            name='micro_ros_transport',
+            default_value='serial',
+            description='micro-ROS transport'
+        ),
+
+        DeclareLaunchArgument(
+            name='micro_ros_port',
+            default_value='8888',
+            description='micro-ROS udp/tcp port number'
+        ),
+
+        DeclareLaunchArgument(
             name='odom_topic', 
             default_value='/odom',
             description='EKF out odometry topic'

--- a/linorobot2_bringup/launch/default_robot.launch.py
+++ b/linorobot2_bringup/launch/default_robot.launch.py
@@ -18,7 +18,7 @@ from launch.substitutions import LaunchConfiguration, PathJoinSubstitution, Pyth
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
-from launch.conditions import IfCondition
+from launch.conditions import IfCondition, LaunchConfigurationEquals, LaunchConfigurationNotEquals
 
 
 def generate_launch_description():
@@ -36,13 +36,37 @@ def generate_launch_description():
             default_value='/dev/ttyACM0',
             description='Linorobot Base Serial Port'
         ),
+
+        DeclareLaunchArgument(
+            name='micro_ros_transport',
+            default_value='serial',
+            description='micro-ROS transport'
+        ),
+
+        DeclareLaunchArgument(
+            name='micro_ros_port',
+            default_value='8888',
+            description='micro-ROS udp/tcp port number'
+        ),
+
         Node(
+            condition=LaunchConfigurationEquals('micro_ros_transport', 'serial'),
             package='micro_ros_agent',
             executable='micro_ros_agent',
             name='micro_ros_agent',
             output='screen',
             arguments=['serial', '--dev', LaunchConfiguration("base_serial_port")]
         ),
+
+        Node(
+            condition=LaunchConfigurationEquals('micro_ros_transport', 'udp4'),
+            package='micro_ros_agent',
+            executable='micro_ros_agent',
+            name='micro_ros_agent',
+            output='screen',
+            arguments=[LaunchConfiguration('micro_ros_transport'), '--port', LaunchConfiguration('micro_ros_port')]
+        ),
+    
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource(description_launch_path)
         ),

--- a/linorobot2_bringup/launch/lasers.launch.py
+++ b/linorobot2_bringup/launch/lasers.launch.py
@@ -44,6 +44,30 @@ def generate_launch_description():
             description='Laser Frame ID'
         ),
 
+        DeclareLaunchArgument(
+            name='lidar_transport',
+            default_value='serial',
+            description='Lidar transport: serial, udp_server, udp_client, tcp_server, tcp_client'
+        ),
+
+        DeclareLaunchArgument(
+            name='lidar_serial_port',
+            default_value='/dev/ttyUSB0',
+            description='Lidar serial port device name'
+        ),
+
+        DeclareLaunchArgument(
+            name='lidar_server_ip',
+            default_value='0.0.0.0',
+            description='Lidar server ip'
+        ),
+
+        DeclareLaunchArgument(
+            name='lidar_server_port',
+            default_value='8889',
+            description='Lidar server port number'
+        ),
+
         Node(
             condition=LaunchConfigurationEquals('sensor', 'ydlidar'),
             package='ydlidar_ros2_driver',
@@ -119,6 +143,75 @@ def generate_launch_description():
                 {'topic_name': LaunchConfiguration('topic_name')},
                 {'lidar_frame': LaunchConfiguration('frame_id')},
                 {'range_threshold': 0.005}
+            ]
+        ),
+
+        Node(
+            condition=LaunchConfigurationEquals('sensor', 'ld06'),
+            package='ldlidar_stl_ros2',
+            executable='ldlidar_stl_ros2_node',
+            name='ld06',
+            output='screen',
+            parameters=[
+                {'product_name': 'LDLiDAR_LD06'},
+                {'topic_name': LaunchConfiguration('topic_name')},
+                {'frame_id': LaunchConfiguration('frame_id')},
+                {'comm_mode': LaunchConfiguration('lidar_transport')},
+                {'port_name': LaunchConfiguration('lidar_serial_port')},
+                {'port_baudrate': 230400},
+                {'server_ip': LaunchConfiguration('lidar_server_ip')},
+                {'server_port': LaunchConfiguration('lidar_server_port')},
+                {'laser_scan_dir': True},
+                {'bins': 456},
+                {'enable_angle_crop_func': False},
+                {'angle_crop_min': 135.0},
+                {'angle_crop_max': 225.0}
+            ]
+        ),
+
+        Node(
+            condition=LaunchConfigurationEquals('sensor', 'ld19'),
+            package='ldlidar_stl_ros2',
+            executable='ldlidar_stl_ros2_node',
+            name='ld19',
+            output='screen',
+            parameters=[
+                {'product_name': 'LDLiDAR_LD19'},
+                {'topic_name': LaunchConfiguration('topic_name')},
+                {'frame_id': LaunchConfiguration('frame_id')},
+                {'comm_mode': LaunchConfiguration('lidar_transport')},
+                {'port_name': LaunchConfiguration('lidar_serial_port')},
+                {'port_baudrate': 230400},
+                {'server_ip': LaunchConfiguration('lidar_server_ip')},
+                {'server_port': LaunchConfiguration('lidar_server_port')},
+                {'laser_scan_dir': True},
+                {'bins': 456},
+                {'enable_angle_crop_func': False},
+                {'angle_crop_min': 135.0},
+                {'angle_crop_max': 225.0}
+            ]
+        ),
+
+        Node(
+            condition=LaunchConfigurationEquals('sensor', 'stl27l'),
+            package='ldlidar_stl_ros2',
+            executable='ldlidar_stl_ros2_node',
+            name='stl27l',
+            output='screen',
+            parameters=[
+                {'product_name': 'LDLiDAR_STL27L'},
+                {'topic_name': LaunchConfiguration('topic_name')},
+                {'frame_id': LaunchConfiguration('frame_id')},
+                {'comm_mode': LaunchConfiguration('lidar_transport')},
+                {'port_name': LaunchConfiguration('lidar_serial_port')},
+                {'port_baudrate': 921600},
+                {'server_ip': LaunchConfiguration('lidar_server_ip')},
+                {'server_port': LaunchConfiguration('lidar_server_port')},
+                {'laser_scan_dir': True},
+                {'bins': 2160},
+                {'enable_angle_crop_func': False},
+                {'angle_crop_min': 135.0},
+                {'angle_crop_max': 225.0}
             ]
         )
     ])


### PR DESCRIPTION
1. add the micro-ROS udp4/wifi transport support to bringup
2. add ldliar stl drivers including ld06, ld19, stl-27l with serial and udp/tcp server/client transports support.

These patches are needed to run esp32 in wifi mode.

Cheers,
Thomas Chou