### PR TITLE
docker: fix sllidar_ros2 source directory

### DIFF
--- a/docker/install_sensors.bash
+++ b/docker/install_sensors.bash
@@ -102,7 +102,7 @@ function install_stl27l {
 
 function install_sllidar_ros2 {
     cd $WORKSPACE
-    git clone https://github.com/Slamtec/sllidar_ros2.git
+    git clone https://github.com/Slamtec/sllidar_ros2.git src/sllidar_ros2
     colcon build
     source $WORKSPACE/install/setup.bash
 }


### PR DESCRIPTION
The location to clone sllidar_ros2 should be under src directory.