### PR TITLE
Added RGB Camera Plugin

### DIFF
--- a/linorobot2_description/urdf/2wd_properties.urdf.xacro
+++ b/linorobot2_description/urdf/2wd_properties.urdf.xacro
@@ -22,4 +22,9 @@
   <xacro:property name="depth_sensor_pose">
     <origin xyz="0.14 0.0 0.045" rpy="0 0 0"/>
   </xacro:property>
+
+  <xacro:property name="front_camera_sensor_pose">
+    <origin xyz="0.05 0.0 0.3" rpy="0 0 0"/>
+  </xacro:property>
+
 </robot>

--- a/linorobot2_description/urdf/2wd_properties.urdf.xacro
+++ b/linorobot2_description/urdf/2wd_properties.urdf.xacro
@@ -23,8 +23,8 @@
     <origin xyz="0.14 0.0 0.045" rpy="0 0 0"/>
   </xacro:property>
 
-  <xacro:property name="front_camera_sensor_pose">
-    <origin xyz="0.05 0.0 0.3" rpy="0 0 0"/>
+  <xacro:property name="rear_camera_sensor_pose">
+    <origin xyz="-0.14 0.0 0.045" rpy="0 0 3.14159"/>
   </xacro:property>
 
 </robot>

--- a/linorobot2_description/urdf/4wd_properties.urdf.xacro
+++ b/linorobot2_description/urdf/4wd_properties.urdf.xacro
@@ -20,4 +20,8 @@
   <xacro:property name="depth_sensor_pose">
     <origin xyz="-0.065 0 0.255" rpy="0 0 0"/>
   </xacro:property>
+
+  <xacro:property name="rear_camera_sensor_pose">
+    <origin xyz="-0.2375 0.0 0.255" rpy="0 0 3.14159"/>
+  </xacro:property>
 </robot>

--- a/linorobot2_description/urdf/mecanum_properties.urdf.xacro
+++ b/linorobot2_description/urdf/mecanum_properties.urdf.xacro
@@ -20,4 +20,8 @@
   <xacro:property name="depth_sensor_pose">
     <origin xyz="0.2375 0 0.06" rpy="0 0 0"/>
   </xacro:property>
+
+  <xacro:property name="rear_camera_sensor_pose">
+    <origin xyz="-0.2375 0.0 0.06" rpy="0 0 3.14159"/>
+  </xacro:property>
 </robot>

--- a/linorobot2_description/urdf/robots/2wd.urdf.xacro
+++ b/linorobot2_description/urdf/robots/2wd.urdf.xacro
@@ -72,9 +72,9 @@
 
   <xacro:rgb_camera
       parent="base_link"
-      name="front_rgb_camera"
-      topic_name="front_rgb_camera">
-    <xacro:insert_block name="front_camera_sensor_pose" />
+      name="rear_rgb_camera"
+      topic_name="rear_rgb_camera/image">
+    <xacro:insert_block name="rear_camera_sensor_pose" />
   </xacro:rgb_camera>
 
   <xacro:diff_drive_controller

--- a/linorobot2_description/urdf/robots/2wd.urdf.xacro
+++ b/linorobot2_description/urdf/robots/2wd.urdf.xacro
@@ -8,6 +8,7 @@
   <xacro:include filename="$(find linorobot2_description)/urdf/sensors/imu.urdf.xacro" />
   <xacro:include filename="$(find linorobot2_description)/urdf/sensors/generic_laser.urdf.xacro" />
   <xacro:include filename="$(find linorobot2_description)/urdf/sensors/depth_sensor.urdf.xacro" />
+  <xacro:include filename="$(find linorobot2_description)/urdf/sensors/camera.urdf.xacro" />
   <xacro:include filename="$(find linorobot2_description)/urdf/controllers/diff_drive.urdf.xacro" />
 
   <xacro:base 
@@ -68,6 +69,13 @@
   <xacro:depth_sensor>
     <xacro:insert_block name="depth_sensor_pose" />
   </xacro:depth_sensor>
+
+  <xacro:rgb_camera
+      parent="base_link"
+      name="front_rgb_camera"
+      topic_name="front_rgb_camera">
+    <xacro:insert_block name="front_camera_sensor_pose" />
+  </xacro:rgb_camera>
 
   <xacro:diff_drive_controller
     wheel_separation="${wheel_pos_y * 2}"

--- a/linorobot2_description/urdf/robots/4wd.urdf.xacro
+++ b/linorobot2_description/urdf/robots/4wd.urdf.xacro
@@ -7,6 +7,7 @@
   <xacro:include filename="$(find linorobot2_description)/urdf/sensors/imu.urdf.xacro" />
   <xacro:include filename="$(find linorobot2_description)/urdf/sensors/generic_laser.urdf.xacro" />
   <xacro:include filename="$(find linorobot2_description)/urdf/sensors/depth_sensor.urdf.xacro" />
+  <xacro:include filename="$(find linorobot2_description)/urdf/sensors/camera.urdf.xacro" />
   <xacro:include filename="$(find linorobot2_description)/urdf/controllers/skid_steer.urdf.xacro" />
 
   <xacro:base 
@@ -66,6 +67,13 @@
   <xacro:depth_sensor>
     <xacro:insert_block name="depth_sensor_pose" />
   </xacro:depth_sensor>
+
+  <xacro:rgb_camera
+      parent="base_link"
+      name="rear_rgb_camera"
+      topic_name="rear_rgb_camera/image">
+    <xacro:insert_block name="rear_camera_sensor_pose" />
+  </xacro:rgb_camera>
 
   <xacro:diff_drive_controller
     wheel_separation="${wheel_pos_y * 2}"

--- a/linorobot2_description/urdf/robots/mecanum.urdf.xacro
+++ b/linorobot2_description/urdf/robots/mecanum.urdf.xacro
@@ -7,6 +7,7 @@
   <xacro:include filename="$(find linorobot2_description)/urdf/sensors/imu.urdf.xacro" />
   <xacro:include filename="$(find linorobot2_description)/urdf/sensors/generic_laser.urdf.xacro" />
   <xacro:include filename="$(find linorobot2_description)/urdf/sensors/depth_sensor.urdf.xacro" />
+  <xacro:include filename="$(find linorobot2_description)/urdf/sensors/camera.urdf.xacro" />
   <xacro:include filename="$(find linorobot2_description)/urdf/controllers/omni_drive.urdf.xacro" />
 
   <xacro:base 
@@ -66,6 +67,13 @@
   <xacro:depth_sensor>
     <xacro:insert_block name="depth_sensor_pose" />
   </xacro:depth_sensor>
+
+  <xacro:rgb_camera
+      parent="base_link"
+      name="rear_rgb_camera"
+      topic_name="rear_rgb_camera/image">
+    <xacro:insert_block name="rear_camera_sensor_pose" />
+  </xacro:rgb_camera>
 
   <xacro:omni_drive_controller/>
 </robot>

--- a/linorobot2_description/urdf/sensors/camera.urdf.xacro
+++ b/linorobot2_description/urdf/sensors/camera.urdf.xacro
@@ -1,0 +1,77 @@
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:property name="M_PI" value="3.1415926535897931" />
+  <xacro:macro name="rgb_camera" params="*origin parent name topic_name">
+    <link name="${name}_link">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <box size="0.030 0.124 0.030"/>
+        </geometry>
+        <material name="blue">
+          <color rgba="0.003 0.223 0.639 1.0"/>
+        </material>
+      </visual>
+      
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+          <box size="0.030 0.124 0.030"/>
+        </geometry>
+      </collision>
+
+      <inertial>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <mass value="0.135"/>
+        <inertia ixx="${(1/12) * 0.135 * ((0.124  * 0.124)  + (0.030 * 0.030))}" ixy="0.0" ixz="0.0"
+                 iyy="${(1/12) * 0.135 * ((0.030 * 0.030) + (0.030 * 0.030))}" iyz="0.0"
+                 izz="${(1/12) * 0.135 * ((0.030 * 0.030) + (0.124  * 0.124))}"/>
+      </inertial>
+    </link>
+    
+    <gazebo reference="${name}_link">  
+      <visual>  
+        <material>
+          <ambient>0.051 0.047 0.416 1.0</ambient>  
+          <diffuse>0.051 0.047 0.416 1.0</diffuse>  
+          <specular>0.051 0.047 0.416 1.0</specular>  
+          <emissive>0.051 0.047 0.416 1.0</emissive>  
+        </material>
+      </visual> 
+    </gazebo>
+
+    <joint name="${name}_to_${parent}" type="fixed">
+      <parent link="${parent}"/>
+      <child link="${name}_link"/>
+      <xacro:insert_block name="origin" />
+    </joint>
+
+    <!-- https://github.com/ros-simulation/gazebo_ros_pkgs/wiki/ROS-2-Migration:-Camera#gazebo_ros_camera -->
+    <gazebo reference="${name}_link">
+      <sensor name="${name}" type="camera">
+        <always_on>true</always_on>
+        <update_rate>30.0</update_rate>
+        <camera name="${name}">
+          <horizontal_fov>1.50098</horizontal_fov>
+          <image>
+            <width>640</width>
+            <height>480</height>
+            <format>R8G8B8</format>
+          </image>
+        </camera>
+        <plugin name="rgb_${name}_controller" filename="libgazebo_ros_camera.so">
+          <ros>
+            <remapping>${name}/image_raw:=${topic_name}</remapping>
+          </ros>
+          <hack_baseline>0.07</hack_baseline>
+          <frame_name>${name}_link</frame_name>
+          <distortion_k1>0.00000001</distortion_k1>
+          <distortion_k2>0.00000001</distortion_k2>
+          <distortion_k3>0.00000001</distortion_k3>
+          <distortion_t1>0.00000001</distortion_t1>
+          <distortion_t2>0.00000001</distortion_t2>
+        </plugin>
+      </sensor>
+
+    </gazebo>
+  </xacro:macro>
+</robot>

--- a/linorobot2_description/urdf/sensors/depth_sensor.urdf.xacro
+++ b/linorobot2_description/urdf/sensors/depth_sensor.urdf.xacro
@@ -66,7 +66,7 @@
             <format>R8G8B8</format>
           </image>
         </camera>
-        <plugin name="camera_controller" filename="libgazebo_ros_camera.so">
+        <plugin name="depth_camera_controller" filename="libgazebo_ros_camera.so">
           <ros>
             <remapping>/camera/camera_info:=/camera/color/camera_info</remapping>
             <remapping>/camera/image_raw:=/camera/color/image_raw</remapping>


### PR DESCRIPTION
Changes:
1. Added `camera.urdf.xacro` for the RGB camera, using the same Gazebo plugin library as the depth camera: `libgazebo_ros_camera.so`, with depth properties disabled.
2. Added rear camera properties to 2WD, 4WD, and mecanum base models.
3. Renamed the depth camera plugin to avoid duplication with the RGB camera.