### PR TITLE
Added Optical Link to camera.urdf.xacro

### DIFF
--- a/linorobot2_description/urdf/sensors/camera.urdf.xacro
+++ b/linorobot2_description/urdf/sensors/camera.urdf.xacro
@@ -45,6 +45,13 @@
       <xacro:insert_block name="origin" />
     </joint>
 
+    <link name="${name}_optical_link"/>
+    <joint name="${name}_optical_joint" type="fixed">
+      <origin xyz="0 0 0" rpy="-1.57 0 -1.57"/>
+      <parent link="${name}_link"/>
+      <child link="${name}_optical_link"/>
+    </joint>
+
     <!-- https://github.com/ros-simulation/gazebo_ros_pkgs/wiki/ROS-2-Migration:-Camera#gazebo_ros_camera -->
     <gazebo reference="${name}_link">
       <sensor name="${name}" type="camera">
@@ -63,7 +70,7 @@
             <remapping>${name}/image_raw:=${topic_name}</remapping>
           </ros>
           <hack_baseline>0.07</hack_baseline>
-          <frame_name>${name}_link</frame_name>
+          <frame_name>${name}_optical_link</frame_name>
           <distortion_k1>0.00000001</distortion_k1>
           <distortion_k2>0.00000001</distortion_k2>
           <distortion_k3>0.00000001</distortion_k3>


### PR DESCRIPTION
Changes:

1. Added an optical link to camera.urdf.xacro to address an issue with detecting AprilTags, which caused incorrect tf generation.
2. The optical link applies a rotation of -pi/2 for roll and yaw orientations relative to the camera link.

Same implementation with the depth camea link used in the depth sensor.