### PR TITLE
change default baudrate to match linorobot2_hardware

### DIFF
--- a/linorobot2_bringup/launch/default_robot.launch.py
+++ b/linorobot2_bringup/launch/default_robot.launch.py
@@ -39,7 +39,7 @@ def generate_launch_description():
 
         DeclareLaunchArgument(
             name='micro_ros_baudrate', 
-            default_value='115200',
+            default_value='921600',
             description='micro-ROS baudrate'
         ),
 


### PR DESCRIPTION
This PR closes issue 174, where the microros baud rate is 115200. It is increased to 921600 as in the hippo5329 repo (rolling branch) to enable a 50Hz loop rate on an ESP32 microcontroller. This PR has a co-requisite issue and PR in the linorobot2_hardware repo.