### PR TITLE
Fix LaunchConfigurationEquals deprecation warning

### DIFF
--- a/linorobot2_bringup/launch/default_robot.launch.py
+++ b/linorobot2_bringup/launch/default_robot.launch.py
@@ -14,11 +14,11 @@
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
-from launch.substitutions import LaunchConfiguration, PathJoinSubstitution, PythonExpression
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution, EqualsSubstitution
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
-from launch.conditions import IfCondition, LaunchConfigurationEquals, LaunchConfigurationNotEquals
+from launch.conditions import IfCondition
 
 
 def generate_launch_description():
@@ -56,21 +56,21 @@ def generate_launch_description():
         ),
 
         Node(
-            condition=LaunchConfigurationEquals('micro_ros_transport', 'serial'),
+            condition=IfCondition(EqualsSubstitution(LaunchConfiguration('micro_ros_transport'), 'serial')),
             package='micro_ros_agent',
             executable='micro_ros_agent',
             name='micro_ros_agent',
             output='screen',
-            arguments=['serial', '--dev', LaunchConfiguration("base_serial_port"), '--baudrate', LaunchConfiguration("micro_ros_baudrate")]
+            arguments=['serial', '--dev', LaunchConfiguration("base_serial_port"), '--baudrate', LaunchConfiguration("micro_ros_baudrate")],
         ),
 
         Node(
-            condition=LaunchConfigurationEquals('micro_ros_transport', 'udp4'),
+            condition=IfCondition(EqualsSubstitution(LaunchConfiguration('micro_ros_transport'), 'udp4')),
             package='micro_ros_agent',
             executable='micro_ros_agent',
             name='micro_ros_agent',
             output='screen',
-            arguments=[LaunchConfiguration('micro_ros_transport'), '--port', LaunchConfiguration('micro_ros_port')]
+            arguments=[LaunchConfiguration('micro_ros_transport'), '--port', LaunchConfiguration('micro_ros_port')],
         ),
     
         IncludeLaunchDescription(

--- a/linorobot2_bringup/launch/depth.launch.py
+++ b/linorobot2_bringup/launch/depth.launch.py
@@ -18,7 +18,7 @@ from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
 from launch.substitutions import PathJoinSubstitution, PythonExpression, LaunchConfiguration
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.substitutions import FindPackageShare
-from launch.conditions import IfCondition, LaunchConfigurationEquals
+from launch.conditions import IfCondition
 from launch_ros.actions import Node
 
 
@@ -45,7 +45,7 @@ def generate_launch_description():
             PythonLaunchDescriptionSource(PathJoinSubstitution(
                 [FindPackageShare('realsense2_camera'), 'launch', 'rs_launch.py']
             )),
-            condition=LaunchConfigurationEquals('sensor', 'realsense'),
+            condition=IfCondition(EqualsSubstitution(LaunchConfiguration('sensor'), 'realsense')),
             launch_arguments={
                 'pointcloud.enable': 'true',
                 'ordered_pc': 'true', 

--- a/linorobot2_bringup/launch/lasers.launch.py
+++ b/linorobot2_bringup/launch/lasers.launch.py
@@ -15,9 +15,9 @@
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution, EqualsSubstitution
 from launch_ros.substitutions import FindPackageShare
-from launch.conditions import LaunchConfigurationEquals
+from launch.conditions import IfCondition
 from launch_ros.actions import Node
 
 
@@ -110,7 +110,7 @@ def generate_launch_description():
         ),
 
         Node(
-            condition=LaunchConfigurationEquals('sensor', 'ydlidar'),
+            condition=IfCondition(EqualsSubstitution(LaunchConfiguration('sensor'), 'ydlidar')),
             package='ydlidar_ros2_driver',
             executable='ydlidar_ros2_driver_node',
             name='ydlidar_ros2_driver_node',
@@ -143,7 +143,7 @@ def generate_launch_description():
         ),
 
         # Node(
-        #     condition=LaunchConfigurationEquals('sensor', 'rplidar'),
+        #     condition=IfCondition(EqualsSubstitution(LaunchConfiguration('sensor'), 'rplidar')),
         #     name='rplidar_composition',
         #     package='rplidar_ros',
         #     executable='rplidar_composition',
@@ -159,7 +159,7 @@ def generate_launch_description():
         # ),
 
         Node( 
-            condition=LaunchConfigurationEquals('sensor', 'xv11'),
+            condition=IfCondition(EqualsSubstitution(LaunchConfiguration('sensor'), 'xv11')),
             name='xv_11_driver',
             package='xv_11_driver',
             executable='xv_11_driver',
@@ -174,7 +174,7 @@ def generate_launch_description():
         ),
 
         Node(
-            condition=LaunchConfigurationEquals('sensor', 'ldlidar'),
+            condition=IfCondition(EqualsSubstitution(LaunchConfiguration('sensor'), 'ldlidar')),
             package='ldlidar',
             executable='ldlidar',
             name='ldlidar',
@@ -188,7 +188,7 @@ def generate_launch_description():
         ),
 
         Node(
-            condition=LaunchConfigurationEquals('sensor', 'ld06'),
+            condition=IfCondition(EqualsSubstitution(LaunchConfiguration('sensor'), 'ld06')),
             package='ldlidar_stl_ros2',
             executable='ldlidar_stl_ros2_node',
             name='ld06',
@@ -211,7 +211,7 @@ def generate_launch_description():
         ),
 
         Node(
-            condition=LaunchConfigurationEquals('sensor', 'ld19'),
+            condition=IfCondition(EqualsSubstitution(LaunchConfiguration('sensor'), 'ld19')),
             package='ldlidar_stl_ros2',
             executable='ldlidar_stl_ros2_node',
             name='ld19',
@@ -234,7 +234,7 @@ def generate_launch_description():
         ),
 
         Node(
-            condition=LaunchConfigurationEquals('sensor', 'stl27l'),
+            condition=IfCondition(EqualsSubstitution(LaunchConfiguration('sensor'), 'stl27l')),
             package='ldlidar_stl_ros2',
             executable='ldlidar_stl_ros2_node',
             name='stl27l',


### PR DESCRIPTION
Replace deprecated LaunchConfigurationEquals functions with IfCondition(EqualsSubstitution(LaunchConfiguration())