### PR TITLE
fixed route server error by adding in package.xml

### DIFF
--- a/linorobot2_navigation/package.xml
+++ b/linorobot2_navigation/package.xml
@@ -11,9 +11,10 @@
   <url type="bugtracker">https://github.com/linorobot/linorobot2/issues</url>
   <buildtool_depend>ament_cmake</buildtool_depend>
   <exec_depend>nav2_bringup</exec_depend>
+  <exec_depend>nav2_route</exec_depend>
+  <exec_depend>slam_toolbox</exec_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
-    <exec_depend>nav2_bringup</exec_depend>
-    <exec_depend>slam_toolbox</exec_depend>
   </export>
 </package>


### PR DESCRIPTION
This PR fixes the ` Waiting for service route_server/get_state...` error due to the missing route_server dependency that has to be explicitly installed. Fix is based on this thread:

[ Waiting for service route_server/get_state...](https://github.com/ros-navigation/navigation2/issues/5634)