### PR TITLE
Fix initial position for turtlebot_world

### DIFF
--- a/linorobot2_gazebo/launch/gazebo.launch.py
+++ b/linorobot2_gazebo/launch/gazebo.launch.py
@@ -82,7 +82,7 @@ def generate_launch_description():
 
         DeclareLaunchArgument(
             name='spawn_x', 
-            default_value='0.0',
+            default_value='0.5',
             description='Robot spawn position in X axis'
         ),
 


### PR DESCRIPTION
Set initial robot x=0.5 so it doesn't start in the middle of the center post in the default world. Fixes Issue #199 