### PR TITLE
removed sharing dev to sync with cpu builds

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -118,7 +118,5 @@ services:
     network_mode: host
     environment:
     - DISPLAY=:200
-    devices:
-    - /dev/dri:/dev/dri
     volumes:
     - ./kasm-autostart:/defaults/autostart


### PR DESCRIPTION
This PR removes the sharing of dev on KasmVNC since it's not being used