### PR TITLE
Default build

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -3,8 +3,8 @@ DOCKER_ROS_DISTRO=jazzy
 
 # Type of installation. Available variables:
 # BASE_IMAGE=hardware
-# BASE_IMAGE=gazebo
-BASE_IMAGE=gazebo-cuda
+BASE_IMAGE=gazebo
+# BASE_IMAGE=gazebo-cuda
 
 # Robot type. Available variables: 2wd 4wd mecanum
 ROBOT_BASE=2wd

--- a/docker/build
+++ b/docker/build
@@ -1,3 +1,4 @@
 #!/bin/bash
 
 HOST_UID=$(id -u) HOST_GID=$(id -g) docker compose build
+docker pull lsiobase/kasmvnc:alpine321


### PR DESCRIPTION
This PR sets the cpu base image build as default and pre-downloads the KasmVNC image during build time.